### PR TITLE
feat(auth-secret): allow using existing secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Key | Description | Default
 `mariadb.auth.database` | Database name to create | `""`
 `mariadb.auth.username` | Database user to create | `""`
 `mariadb.auth.password` | Password for the user | `""`
+`mariadb.authExistingSecret` | Existing secret for mariadb auth | `""`
 `ingress.enabled` | Enable use of ingress controllers | `true`
 `ingress.tls` | Use dedicated certificates | `true`
 `ingress.hosts` | OCS hosts to create application URLs | `""`

--- a/charts/ocsinventory/templates/deployment.yaml
+++ b/charts/ocsinventory/templates/deployment.yaml
@@ -34,22 +34,22 @@ spec:
           - name: OCS_DB_NAME
             valueFrom:
               secretKeyRef:
-                  name: {{ template "ocsinventory.fullname" . }}
+                  name: {{ default (template "ocsinventory.fullname" .) .Values.mariadb.authExistingSecret }}
                   key: db-name
           - name: OCS_DB_PASS
             valueFrom:
               secretKeyRef:
-                  name: {{ template "ocsinventory.fullname" . }}
+                  name: {{ default (template "ocsinventory.fullname" .) .Values.mariadb.authExistingSecret }}
                   key: db-pass
           - name: OCS_DB_SERVER
             valueFrom:
               secretKeyRef:
-                  name: {{ template "ocsinventory.fullname" . }}
+                  name: {{ default (template "ocsinventory.fullname" .) .Values.mariadb.authExistingSecret }}
                   key: db-host
           - name: OCS_DB_USER
             valueFrom:
               secretKeyRef:
-                  name: {{ template "ocsinventory.fullname" . }}
+                  name: {{ default (template "ocsinventory.fullname" .) .Values.mariadb.authExistingSecret }}
                   key: db-user
           - name: OCS_SSL_ENABLED
             value: "0"

--- a/charts/ocsinventory/templates/secret.yaml
+++ b/charts/ocsinventory/templates/secret.yaml
@@ -4,10 +4,9 @@ metadata:
   name: {{ template "ocsinventory.fullname" . }}
   labels:
     {{- include "ocsinventory.labels" . | nindent 4 }}
-
 type: Opaque
 data:
-  {{- if .Values.mariadb.enabled }}
+  {{- if and .Values.mariadb.enabled (not .Values.mariadb.authExistingSecret) }}
   db-pass: {{ required "A password is required!" .Values.mariadb.auth.password | b64enc | quote }}
   db-user: {{ required "A username is required!" .Values.mariadb.auth.username | b64enc | quote }}
   db-name: {{ required "A db name is required!" .Values.mariadb.auth.database | b64enc | quote }}

--- a/charts/ocsinventory/values.yaml
+++ b/charts/ocsinventory/values.yaml
@@ -72,6 +72,7 @@ mariadb:
     database: ""
     username: ""
     password: ""
+  authExistingSecret: ""
 
 ## Allowing use of ingress controllers
 ## https://kubernetes.io/docs/concepts/services-networking/ingress/


### PR DESCRIPTION
## Context

To avoid having password in plain-text, we need to be able to use an existing secret (that we provide with external-secrets).